### PR TITLE
Adding jsvalidator to the repo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "apollo-server-express": "2.4.8",
     "graphql": "14.0.2",
+    "jsvalidator" : "1.2.0",
     "lodash": "4.17.11",
     "mongodb": "3.1.10"
   },


### PR DESCRIPTION
Getting an error http://prntscr.com/pl5mv8 on an app the does not require jsvalidator and is only pulling in the schema loader. Either way the container is looking for jsvaliator which is not a package that is available to it, and must be installed on an application to bypass this error.